### PR TITLE
Feature: 세션 인증 방식 도입으로 권한 확인

### DIFF
--- a/src/main/java/com/example/newsforeveryone/user/config/SecurityConfig.java
+++ b/src/main/java/com/example/newsforeveryone/user/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.example.newsforeveryone.user.config;
 
-import com.example.newsforeveryone.user.service.CustomUserDetailsService;
+import com.example.newsforeveryone.user.config.auth.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +12,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -19,6 +20,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
   private final CustomUserDetailsService userDetailService;
+  private final UserIdInjectionFilter userIdInjectionFilter;
 
   @Bean
   public PasswordEncoder passwordEncoder() {
@@ -27,13 +29,15 @@ public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
     return http
         .csrf(csrf -> csrf.disable())
-        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/", "/index.html", "/favicon.ico", "/assets/index-*.js", "/assets/index-*.css", "/api/users", "/api/users/login").permitAll()  //회원가입, 로그인은 허용 경로
             .anyRequest().authenticated())  //허용 경로를 제외한 모든 요청은 인증 필요
+        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS))
         .userDetailsService(userDetailService)
+        .addFilterAfter(userIdInjectionFilter, UsernamePasswordAuthenticationFilter.class)
         .build();
   }
 

--- a/src/main/java/com/example/newsforeveryone/user/config/UserIdInjectionFilter.java
+++ b/src/main/java/com/example/newsforeveryone/user/config/UserIdInjectionFilter.java
@@ -1,0 +1,37 @@
+package com.example.newsforeveryone.user.config;
+
+import com.example.newsforeveryone.user.config.auth.CustomUserDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class UserIdInjectionFilter extends OncePerRequestFilter {
+
+  private static final String USER_ID_HEADER = "MoNew-Request-User-ID";
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain
+  ) throws ServletException, IOException {
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (authentication != null && authentication.isAuthenticated()
+        && authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+
+      // 사용자 ID를 요청 헤더에 설정
+      request.setAttribute(USER_ID_HEADER, userDetails.getUserId());
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/example/newsforeveryone/user/config/auth/CustomUserDetails.java
+++ b/src/main/java/com/example/newsforeveryone/user/config/auth/CustomUserDetails.java
@@ -1,0 +1,16 @@
+package com.example.newsforeveryone.user.config.auth;
+
+import lombok.Getter;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+@Getter
+public class CustomUserDetails extends org.springframework.security.core.userdetails.User {
+  private final Long userId;
+
+  public CustomUserDetails(String email, String password, Long userId) {
+    super(email, password, AuthorityUtils.createAuthorityList("USER"));
+    this.userId = userId;
+  }
+
+}
+

--- a/src/main/java/com/example/newsforeveryone/user/config/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/example/newsforeveryone/user/config/auth/CustomUserDetailsService.java
@@ -1,4 +1,4 @@
-package com.example.newsforeveryone.user.service;
+package com.example.newsforeveryone.user.config.auth;
 
 import com.example.newsforeveryone.user.entity.User;
 import com.example.newsforeveryone.user.repository.UserRepository;
@@ -19,10 +19,10 @@ public class CustomUserDetailsService implements UserDetailsService {
     User user = userRepository.findByEmailAndDeletedAtIsNull(email)
         .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다"));
 
-    return org.springframework.security.core.userdetails.User
-        .withUsername(user.getEmail())
-        .password(user.getPassword())
-        .roles("USER")
-        .build();
+    return new CustomUserDetails(
+        user.getEmail(),
+        user.getPassword(),
+        user.getId()
+    );
   }
 }

--- a/src/main/java/com/example/newsforeveryone/user/service/UserService.java
+++ b/src/main/java/com/example/newsforeveryone/user/service/UserService.java
@@ -10,11 +10,11 @@ import java.util.List;
 public interface UserService {
 
   UserResponse signup(UserSignupRequest request);
-  UserResponse login(UserLoginRequest request);
   void softDeleteUser(Long userId, Long requestUserId);
   void hardDeleteUser(Long userId, Long requestUserId);
   UserResponse updateUserNickname(Long userId, UserUpdateRequest request, Long requestUserId);
   User findActiveUserById(Long userId);
   List<UserResponse> findAllActiveUsers();
+  User findUserByEmail(String email);
 
 }


### PR DESCRIPTION
- spring security에서 제공하는 session생성 도입
- ### 🔐 1. 인증 (Authentication) 흐름

### 로그인 시 (POST `/api/users/login`):

1. 클라이언트가 이메일 + 비밀번호로 로그인 요청
2. `AuthenticationManager`가 `CustomUserDetailsService`를 통해 사용자 정보를 DB에서 조회
3. 비밀번호 일치 확인 (`BCrypt`)
4. `CustomUserDetails` 객체가 인증 정보로 생성됨
5. 인증 정보(`Authentication`)를 `SecurityContextHolder`에 저장
6. **세션 생성 + 인증 정보 저장**:
    
    ```java
    session.setAttribute("SPRING_SECURITY_CONTEXT", SecurityContextHolder.getContext());
    
    ```
    
7. 클라이언트는 `JSESSIONID` 쿠키를 응답으로 받고, 이후 요청에 자동 포함

> ✅ 즉, 세션 기반 인증 방식을 사용하고 있고, 인증은 성공하면 유지됨 (세션 유효 시)
> 

---

### 🔒 2. 인가 (Authorization) 흐름

### Spring Security 설정에서:

```java
.authorizeHttpRequests(auth -> auth
    .requestMatchers(
        "/", "/index.html", "/favicon.ico",
        "/assets/index-*.js", "/assets/index-*.css",
        "/api/users", "/api/users/login"
    ).permitAll()
    .anyRequest().authenticated()
)

```

- `/api/users`, `/api/users/login` → 로그인 없이 접근 가능
- 그 외 모든 요청 → **인증된 사용자만 접근 가능**

> ✅ 즉, /api/interests, /api/articles, /api/users/{userId} 등의 요청은 로그인하지 않으면 403 Unauthorized 발생
