### PR TITLE
refactor: aws 배포 시 메모리 부족으로 배포 실패 -> 페이지네이션 쿼리 최적화

### DIFF
--- a/src/test/java/com/example/newsforeveryone/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/example/newsforeveryone/comment/service/CommentServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.example.newsforeveryone.comment.entity.Comment;
 import com.example.newsforeveryone.support.IntegrationTestSupport;
 import com.example.newsforeveryone.comment.dto.CommentCreateRequest;
 import com.example.newsforeveryone.comment.dto.CommentLikeResponse;
@@ -18,10 +19,15 @@ import com.example.newsforeveryone.newsarticle.entity.NewsArticle;
 import com.example.newsforeveryone.user.entity.User;
 import com.example.newsforeveryone.user.repository.UserRepository;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.example.newsforeveryone.newsarticle.repository.NewsArticleRepository;
@@ -303,6 +309,186 @@ class CommentServiceTest extends IntegrationTestSupport {
         () -> commentService.softDeleteComment(nonExistentCommentId, testUser1.getId()))
         .isInstanceOf(BaseException.class)
         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
+  }
+
+  @Nested
+  @DisplayName("커서 기반 페이지네이션 정렬 테스트")
+  class CursorPaginationTests {
+
+    private List<Comment> comments = new ArrayList<>();
+
+    @BeforeEach
+    void setupComments() throws InterruptedException {
+      // 테스트를 위한 댓글 5개 생성 (생성 시간 간격을 두어 순서 보장)
+      for (int i = 1; i <= 5; i++) {
+        Comment comment = Comment.builder()
+            .articleId(articleId)
+            .userId(testUser1.getId())
+            .content("댓글 " + i)
+            .build();
+        comments.add(commentRepository.save(comment));
+        Thread.sleep(10); // createdAt 순서를 명확하게 하기 위함
+      }
+      Collections.reverse(comments); // 최신순으로 정렬 (댓글 5, 4, 3, 2, 1)
+    }
+
+    @DisplayName("최신순으로 페이지네이션 동작")
+    @Test
+    void testPaginationByCreatedAtDesc() {
+      // given : 페이지 크기는 2
+      int limit = 2;
+
+      // when : 첫 페이지 조회
+      CommentListResponse page1 = commentService.getComments(articleId, "createdAt", "DESC", null,
+          null, limit, testUser1.getId());
+
+      // then : 첫 페이지 결과 검증
+      assertThat(page1.content()).hasSize(limit);
+      assertThat(page1.hasNext()).isTrue();
+      // 최신 댓글 2개 (댓글 5, 댓글 4)가 순서대로 오는지 확인
+      assertThat(page1.content().get(0).id()).isEqualTo(String.valueOf(comments.get(0).getId()));
+      assertThat(page1.content().get(1).id()).isEqualTo(String.valueOf(comments.get(1).getId()));
+
+      // given : 첫 페이지의 마지막 댓글을 커서로 사용
+      String cursor = page1.nextCursor();
+      Long after = Long.valueOf(page1.nextAfter());
+
+      // when : 두 번째 페이지 조회
+      CommentListResponse page2 = commentService.getComments(articleId, "createdAt", "DESC",
+          cursor, after, limit, testUser1.getId());
+
+      // then : 두 번째 페이지 결과 검증
+      assertThat(page2.content()).hasSize(limit);
+      assertThat(page2.hasNext()).isTrue();
+      // 다음 최신 댓글 2개 (댓글 3, 댓글 2)가 순서대로 오는지 확인
+      assertThat(page2.content().get(0).id()).isEqualTo(String.valueOf(comments.get(2).getId()));
+      assertThat(page2.content().get(1).id()).isEqualTo(String.valueOf(comments.get(3).getId()));
+
+      // given : 두 번째 페이지의 마지막 댓글을 커서로 사용
+      cursor = page2.nextCursor();
+      after = Long.valueOf(page2.nextAfter());
+
+      // when : 세 번째 페이지 조회
+      CommentListResponse page3 = commentService.getComments(articleId, "createdAt", "DESC",
+          cursor, after, limit, testUser1.getId());
+
+      // then : 세 번째 페이지 결과 검증
+      assertThat(page3.content()).hasSize(1);
+      assertThat(page3.hasNext()).isFalse();
+      // 마지막 댓글 (댓글 1)이 오는지 확인
+      assertThat(page3.content().get(0).id()).isEqualTo(String.valueOf(comments.get(4).getId()));
+    }
+
+    @DisplayName("오래된순으로 페이지네이션 동작")
+    @Test
+    void testPaginationByCreatedAtAsc() {
+      // given
+      int limit = 2;
+      List<Comment> oldestFirst = comments.stream()
+          .sorted(Comparator.comparing(Comment::getCreatedAt))
+          .collect(Collectors.toList());
+
+      // when : 첫 페이지 조회
+      CommentListResponse page1 = commentService.getComments(articleId, "createdAt", "ASC", null,
+          null, limit, testUser1.getId());
+
+      // then : 첫 페이지 결과 검증
+      assertThat(page1.content()).hasSize(limit);
+      assertThat(page1.hasNext()).isTrue();
+      assertThat(page1.content().get(0).id()).isEqualTo(String.valueOf(oldestFirst.get(0).getId()));
+      assertThat(page1.content().get(1).id()).isEqualTo(String.valueOf(oldestFirst.get(1).getId()));
+
+      // given
+      String cursor = page1.nextCursor();
+      Long after = Long.valueOf(page1.nextAfter());
+
+      // when
+      CommentListResponse page2 = commentService.getComments(articleId, "createdAt", "ASC", cursor,
+          after, limit, testUser1.getId());
+
+      // then
+      assertThat(page2.content()).hasSize(limit);
+      assertThat(page2.hasNext()).isTrue();
+      assertThat(page2.content().get(0).id()).isEqualTo(String.valueOf(oldestFirst.get(2).getId()));
+      assertThat(page2.content().get(1).id()).isEqualTo(String.valueOf(oldestFirst.get(3).getId()));
+    }
+
+    @DisplayName("좋아요 많은순으로 페이지네이션 동작")
+    @Test
+    void testPaginationByLikeCountDesc() {
+      // given: 댓글마다 좋아요 수를 다르게 설정
+      // 댓글 5: 좋아요 3개
+      // 댓글 4: 좋아요 2개
+      // 댓글 3: 좋아요 2개 (ID는 댓글 4보다 작음)
+      // 댓글 2: 좋아요 1개
+      // 댓글 1: 좋아요 0개
+      addLikes(comments.get(0), 3); // 댓글 5
+      addLikes(comments.get(1), 2); // 댓글 4
+      addLikes(comments.get(2), 2); // 댓글 3
+      addLikes(comments.get(3), 1); // 댓글 2
+
+      // 예상 정렬 순서: 댓글5(3) > 댓글4(2) > 댓글3(2) > 댓글2(1) > 댓글1(0)
+      // ID는 DESC로 2차 정렬되므로, 좋아요 수가 같으면 ID가 큰 댓글4가 댓글3보다 먼저 와야 함
+      List<Comment> expectedOrder = List.of(
+          comments.get(0), comments.get(1), comments.get(2), comments.get(3), comments.get(4)
+      );
+      int limit = 2;
+
+      // when : 첫 페이지 조회
+      CommentListResponse page1 = commentService.getComments(articleId, "likeCount", "DESC", null,
+          null, limit, testUser1.getId());
+
+      // then : 첫 페이지 결과 검증
+      assertThat(page1.content()).hasSize(limit);
+      assertThat(page1.hasNext()).isTrue();
+      assertThat(page1.content().get(0).id()).isEqualTo(String.valueOf(expectedOrder.get(0).getId()));
+      assertThat(page1.content().get(1).id()).isEqualTo(String.valueOf(expectedOrder.get(1).getId()));
+      assertThat(page1.content().get(0).likeCount()).isEqualTo(3L);
+      assertThat(page1.content().get(1).likeCount()).isEqualTo(2L);
+
+
+      // given
+      String cursor = page1.nextCursor(); // 이 값은 사용되지 않음 (구현상 after만 사용)
+      Long after = Long.valueOf(page1.nextAfter());
+
+      // when : 두 번째 페이지 조회
+      CommentListResponse page2 = commentService.getComments(articleId, "likeCount", "DESC",
+          cursor, after, limit, testUser1.getId());
+
+      // then : 두 번째 페이지 결과 검증
+      assertThat(page2.content()).hasSize(limit);
+      assertThat(page2.hasNext()).isTrue();
+      assertThat(page2.content().get(0).id()).isEqualTo(String.valueOf(expectedOrder.get(2).getId()));
+      assertThat(page2.content().get(1).id()).isEqualTo(String.valueOf(expectedOrder.get(3).getId()));
+      assertThat(page2.content().get(0).likeCount()).isEqualTo(2L);
+      assertThat(page2.content().get(1).likeCount()).isEqualTo(1L);
+
+      // given
+      cursor = page2.nextCursor();
+      after = Long.valueOf(page2.nextAfter());
+
+      // when : 세 번째 페이지 조회
+      CommentListResponse page3 = commentService.getComments(articleId, "likeCount", "DESC",
+          cursor, after, limit, testUser1.getId());
+
+      // then : 세 번째 페이지 결과 검증
+      assertThat(page3.content()).hasSize(1);
+      assertThat(page3.hasNext()).isFalse();
+      assertThat(page3.content().get(0).id()).isEqualTo(String.valueOf(expectedOrder.get(4).getId()));
+      assertThat(page3.content().get(0).likeCount()).isEqualTo(0L);
+    }
+
+    private void addLikes(Comment comment, int count) {
+      // 좋아요 추가를 위해 임시 사용자 생성 및 저장
+      for (int i = 0; i < count; i++) {
+        User tempUser = userRepository.save(User.builder()
+            .email("likeUser" + comment.getId() + "_" + i + "@test.com")
+            .nickname("likeUser" + i)
+            .password("password")
+            .build());
+        commentService.likeComment(comment.getId(), tempUser.getId());
+      }
+    }
   }
 
   private NewsArticle saveNewsArticle(String link) {


### PR DESCRIPTION
[Refactor] 댓글 조회 기능 메모리 최적화 및 커서 기반 페이지네이션 로직 개선
🔍 변경된 내용
CommentRepository: 파라미터에 따라 동적으로 분기하던 복잡한 JPQL 쿼리(findCommentsWithCursor)를 정렬 조건별(날짜/좋아요, 오름/내림차순)로 분리된 8개의 단순한 쿼리로 리팩토링했습니다.

CommentServiceImpl: 분리된 Repository 쿼리들을 호출하도록 서비스 로직을 수정했습니다. orderBy, direction 파라미터에 따라 적절한 쿼리를 선택하는 역할을 이제 Java 코드가 담당합니다.

버그 수정: 좋아요 순 정렬 시, 커서 값으로 좋아요 수(숫자)가 전달되어 DateTimeParseException이 발생하던 문제를 해결했습니다.

📄 관련 이슈
Closes # (이슈가 있다면 여기에 이슈 번호를 기입하세요)

✍️ PR 유형
[ ] 신규 기능 추가

[x] 버그 수정

[x] 리팩토링

[ ] 문서 업데이트

[ ] 기타

❓ 배경
기존 댓글 조회 쿼리는 CASE 분기문을 사용하여 모든 정렬 및 페이지네이션 시나리오를 한 번에 처리하도록 구현되었습니다. 이 방식은 로컬 개발 환경에서는 문제가 없었으나, 메모리가 제한적인 AWS 배포 환경에서는 OutOfMemoryError: Java heap space를 유발하여 애플리케이션 배포에 실패하는 심각한 문제를 야기했습니다.

주요 원인은 애플리케이션 시작 시 JPA(Hibernate)가 복잡한 JPQL 쿼리를 분석하고 실행 계획을 생성하는 과정에서 과도한 메모리를 점유했기 때문입니다.

💡 해결 방안
"SQL에게 시켰던 복잡한 '경우의 수' 판단을 Java 코드로 옮겨와 데이터베이스와 JPA의 부담을 줄이자" 라는 전략을 채택했습니다.

쿼리 분리 (Specialization):
하나의 거대한 만능 쿼리 대신, 각 정렬 시나리오에 최적화된 여러 개의 단순하고 명확한 전문 쿼리로 분리했습니다.

findFirstPageByCreatedAtDesc

findNextPageByLikeCountAsc 등

각 쿼리는 CASE 문 없이 단 하나의 목적만 수행하므로, JPA가 분석하고 메모리에 올릴 때의 부담이 획기적으로 줄어듭니다.

역할의 위임 (Delegation):
어떤 전문 쿼리를 사용할지 '판단'하는 역할은 CommentServiceImpl의 fetchComments 메서드가 담당하도록 로직을 옮겼습니다. Java의 if-else 분기문은 이 역할을 SQL의 CASE 문보다 훨씬 효율적으로 처리할 수 있습니다.

✅ 결과
메모리 문제 해결: 애플리케이션이 AWS 배포 환경에서 메모리 부족 현상 없이 안정적으로 시작되고 동작하는 것을 확인했습니다.

기능 유지: 기존의 커서 기반 페이지네이션 기능(최신순, 오래된순, 좋아요 많은순, 좋아요 적은순)은 손실 없이 모두 정상적으로 작동합니다.

유지보수성 향상: 각 쿼리의 역할이 명확해져 코드를 이해하고 추후 수정하기가 더 용이해졌습니다.

