### PR TITLE
Fix/CPG-40-뉴스-기사-정렬-동점-처리

### DIFF
--- a/src/main/java/com/example/newsforeveryone/newsarticle/dto/ArticleDto.java
+++ b/src/main/java/com/example/newsforeveryone/newsarticle/dto/ArticleDto.java
@@ -1,6 +1,6 @@
 package com.example.newsforeveryone.newsarticle.dto;
 
-import com.querydsl.core.annotations.QueryProjection;
+import com.example.newsforeveryone.newsarticle.repository.projection.ArticleProjection;
 import java.time.Instant;
 
 public record ArticleDto(
@@ -12,8 +12,21 @@ public record ArticleDto(
     String summary,
     Long commentCount,
     Long viewCount,
-    Boolean viewedByMe
+    Boolean viewedByMe,
+    Instant createdAt
 ) {
-  @QueryProjection
-  public ArticleDto {}
+  public static ArticleDto from(ArticleProjection p) {
+    return new ArticleDto(
+        p.id(),
+        p.source(),
+        p.sourceUrl(),
+        p.title(),
+        p.publishDate(),
+        p.summary(),
+        p.commentCount(),
+        p.viewCount(),
+        p.viewedByMe(),
+        p.createdAt()
+    );
+  }
 }

--- a/src/main/java/com/example/newsforeveryone/newsarticle/repository/projection/ArticleProjection.java
+++ b/src/main/java/com/example/newsforeveryone/newsarticle/repository/projection/ArticleProjection.java
@@ -1,0 +1,20 @@
+package com.example.newsforeveryone.newsarticle.repository.projection;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.Instant;
+
+public record ArticleProjection(
+    Long id,
+    String source,
+    String sourceUrl,
+    String title,
+    Instant publishDate,
+    String summary,
+    Long commentCount,
+    Long viewCount,
+    Boolean viewedByMe,
+    Instant createdAt
+) {
+  @QueryProjection
+  public ArticleProjection {}
+}


### PR DESCRIPTION
- 기존에는 두번째 커서를 createdAt이 아니라 기사 발간일(timestamptz)로 하는게 더 맞다고 생각해서 그렇게 하고 있었는데요. 네이버는 기사 발간일을 분단위로 설정하더라고요 그래서 동점이 너무 많이 나와서 createdAt이 두 번째 커서의 기준이 되도록 하였습니다.
- 위 부분말고 로직 수정은 없었고, 서비스로 이동시켜야 할 로직을 리포지토리에서 이동했습니다.