### PR TITLE
Fix: NaverNews Reader 오류 수정

### DIFF
--- a/src/main/java/com/example/newsforeveryone/newsarticle/batch/reader/NaverItemReader.java
+++ b/src/main/java/com/example/newsforeveryone/newsarticle/batch/reader/NaverItemReader.java
@@ -44,12 +44,17 @@ public class NaverItemReader implements ItemReader<NaverItemDto> {
   @Override
   public NaverItemDto read() {
     if (currentItemIndexInBuffer >= itemBuffer.size()) {
-      fetchItemsForNextKeyword();
-    }
-
-    if (itemBuffer.isEmpty() || currentItemIndexInBuffer >= itemBuffer.size()) {
-      log.info("네이버 키워드 검색 완료");
-      return null;
+      while(true){
+        fetchItemsForNextKeyword();
+        if(currentKeywordIndex >= keywords.size()){
+          log.info("네이버 키워드 검색 완료");
+          return null;
+        }
+        else if(itemBuffer.isEmpty()){
+          log.info("키워드로 검색된 기사 없음");
+        }
+        else break;
+      }
     }
 
     return itemBuffer.get(currentItemIndexInBuffer++);


### PR DESCRIPTION
네이버 API호출 횟수를 확인해봤을 때, 잘 안 불러와지는 것을 확인함.
원인: "ㄱㄷ쟈ㅐ베ㅕㅈ뱌ㅐ헨밍;ㄹ" 와 같은 이상한 키워드가 들어왔을 때, 네이버에서 0개의 item을 반환하고 있었음. 그런데 원래 로직은 0개의 item이 반환될 경우 키워드를 다 검색한 걸로 처리하고 있었음.

